### PR TITLE
Refactor to Simple HashMap. Docs. New Interface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,12 +3,6 @@
 version = 3
 
 [[package]]
-name = "adler"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
-
-[[package]]
 name = "aho-corasick"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -19,15 +13,15 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.57"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08f9b8508dccb7687a1d6c4ce66b2b0ecef467c94667de27d8d7fe1f8d2a9cdc"
+checksum = "bb07d2053ccdbe10e2af2995a2f116c1330396493dc1269f6a91d0ae82e19704"
 
 [[package]]
 name = "async-stream"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171374e7e3b2504e0e5236e3b59260560f9fe94bfe9ac39ba5e4e929c5590625"
+checksum = "dad5c83079eae9969be7fadefe640a1c566901f05ff91ab221de4b6f68d9507e"
 dependencies = [
  "async-stream-impl",
  "futures-core",
@@ -35,9 +29,9 @@ dependencies = [
 
 [[package]]
 name = "async-stream-impl"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "648ed8c8d2ce5409ccd57453d9d1b214b342a0d69376a6feda1fd6cae3299308"
+checksum = "10f203db73a71dfa2fb6dd22763990fa26f3d2625a6da2da900d23b87d26be27"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -52,9 +46,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "aws-config"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "588c761aa9f0587106d77c6523b59b49532ebb6c048052fe878f9f8a3c830599"
+checksum = "2f790682283e9fa42799d4800900e5c2f9a2e67b133a276d74c2f6118f7c24ce"
 dependencies = [
  "aws-http",
  "aws-sdk-sso",
@@ -79,9 +73,9 @@ dependencies = [
 
 [[package]]
 name = "aws-endpoint"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04619a4c0339675fdb7082a3c2a1799bf2b6398fbe0889d69a14f2bd130feb67"
+checksum = "d31dc5bfe810432f2d87465dd6633134e097d19e1a10315446b82a63873552f7"
 dependencies = [
  "aws-smithy-http",
  "aws-types",
@@ -92,9 +86,9 @@ dependencies = [
 
 [[package]]
 name = "aws-http"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d023c3e17c572f3c071699763ad5035ea6e94f3ecf5712c301355beef0c80893"
+checksum = "1d41b649924d2d925e387dc3e9860248c2fd806e783fbc69dbda264878272929"
 dependencies = [
  "aws-smithy-http",
  "aws-smithy-types",
@@ -107,9 +101,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssm"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79739f0256078009388bc3e08e103f8b28384aae49146b6d02e80e251ecd5504"
+checksum = "e1ddf55b176e465b81933bcb7ea797f8bbcbe953934a58f8148d0e7bdceff2bb"
 dependencies = [
  "aws-endpoint",
  "aws-http",
@@ -130,9 +124,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06d3a467637b986708c9299a4031ea120680b43056ee9013f79aa8e949467fa8"
+checksum = "8ab3dfc4f61d6f5261269c15b087c2aa36a1b0570dce484fa116003696986f4e"
 dependencies = [
  "aws-endpoint",
  "aws-http",
@@ -152,9 +146,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa1ba5309db9d1c988c53a57eb80f6ccf9af4626b11068ba48e457fdab3aacf"
+checksum = "89015f25572643bb1bcf7490da9feeecdde23eca0c1a0e98d07fdf4547f89e51"
 dependencies = [
  "aws-endpoint",
  "aws-http",
@@ -174,9 +168,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sig-auth"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c9d556c7432b15b180c4d7015dfe16050ce86fd82602efb7aa415cd7929b4ea"
+checksum = "a75b0895f0f5e5e40851e716041882b9e44d4bb21c68d50b083ea5dcd46378cf"
 dependencies = [
  "aws-sigv4",
  "aws-smithy-http",
@@ -187,9 +181,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sigv4"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47f44f6f9aecc1ccbf3d410d6f00552046a4c808c320b51bdd72df0baa6cbbc1"
+checksum = "a415b5e9401847f97e925b2d8a6b398a4422db6dc036234a681900798e1c396e"
 dependencies = [
  "aws-smithy-http",
  "form_urlencoded",
@@ -199,15 +193,15 @@ dependencies = [
  "percent-encoding",
  "regex",
  "ring",
- "time",
+ "time 0.3.11",
  "tracing",
 ]
 
 [[package]]
 name = "aws-smithy-async"
-version = "0.43.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd107a426047cff81691b598ce5b9488bf23d8b8fd803564c8aad4046521d069"
+checksum = "2659762757c7c13b87a7473a383fddd09a56cfea14528a8606255506167131d7"
 dependencies = [
  "futures-util",
  "pin-project-lite",
@@ -217,9 +211,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-client"
-version = "0.43.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14afb75139d67d3e076afbdc25110d409573e941e69ce1434d7d85107a2886f4"
+checksum = "ba658f0c70f4d8aacf1f8d522d1e5082a86c1c3c036cb6e017aab97d0e5e32a7"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
@@ -241,9 +235,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http"
-version = "0.43.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1976aaf680a01d5ca920cc5834bb808576e803845107907b991d6a441747098b"
+checksum = "3cb3bd864edb558c2fdad04cea99f2bafa2ad9cde4a78048273b534be8b34cf9"
 dependencies = [
  "aws-smithy-types",
  "bytes",
@@ -256,15 +250,15 @@ dependencies = [
  "percent-encoding",
  "pin-project",
  "tokio",
- "tokio-util 0.7.3",
+ "tokio-util",
  "tracing",
 ]
 
 [[package]]
 name = "aws-smithy-http-tower"
-version = "0.43.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba6a7a52b67bab2277e677e656970ed38e06b9f74e42c37a54f7f61550d3264d"
+checksum = "44dc4d903a0629df43f9787ac28db8a0fe5b62e3b8d803812c9a122b8a69ac1a"
 dependencies = [
  "aws-smithy-http",
  "bytes",
@@ -277,18 +271,18 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-json"
-version = "0.43.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "168c5afb872e8d11f086bfa0157833293d2cac0ab66176690a887ad1367dd4a7"
+checksum = "3abdf01b1642ea4eccc3a89bbe636160f9926bd81c99e5c58970ef92139f5184"
 dependencies = [
  "aws-smithy-types",
 ]
 
 [[package]]
 name = "aws-smithy-query"
-version = "0.43.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "306dc0963ee08df39ba50969c20926718a3efa5061bb15e54082c1f74335bf86"
+checksum = "b8e8c6411ed3eadf48253e505e0ec54fff9010732593c1163e522d473e467f5f"
 dependencies = [
  "aws-smithy-types",
  "urlencoding",
@@ -296,30 +290,30 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "0.43.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72afd4e14f068f773d53123b28cabbfd44cfb1f69418f83fa16f2fca65959daf"
+checksum = "d60bf15d33cbbe6cf0708a6908fab91166187550ac963c62427d2befea8e648f"
 dependencies = [
- "itoa 1.0.1",
+ "itoa",
  "num-integer",
  "ryu",
- "time",
+ "time 0.3.11",
 ]
 
 [[package]]
 name = "aws-smithy-xml"
-version = "0.43.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b606d35369febb651b1911039731625a23102cf775bde10295a2cf9a722de55a"
+checksum = "b7c547d21db127067775234b1dac68c584a9d389e2dcea67cc46e18640254205"
 dependencies = [
  "xmlparser",
 ]
 
 [[package]]
 name = "aws-types"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b500c108f8aa03ff2a401373abcc20e7752795ecd6fa6d4628e606d0d26a23"
+checksum = "40d4a682b35d27cd73ef1beebdbfcdf7686b6cbf8bb76a2983d219a17ce73559"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-client",
@@ -345,15 +339,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bumpalo"
-version = "3.9.1"
+version = "3.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a45a46ab1f2412e53d3a0ade76ffad2025804294569aae387231a0cd6e0899"
-
-[[package]]
-name = "byteorder"
-version = "1.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+checksum = "37ccbd214614c6783386c1af30caf03192f17891059cecc394b4fb119e363de3"
 
 [[package]]
 name = "bytes"
@@ -363,9 +351,9 @@ checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
 
 [[package]]
 name = "bytes-utils"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e314712951c43123e5920a446464929adc667a5eade7f8fb3997776c9df6e54"
+checksum = "1934a3ef9cac8efde4966a92781e77713e1ba329f1d42e446c7d7eba340d8ef1"
 dependencies = [
  "bytes",
  "either",
@@ -373,9 +361,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.72"
+version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22a9137b95ea06864e018375b72adfb7db6e6f68cfc8df5a04d00288050485ee"
+checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
 
 [[package]]
 name = "cfg-if"
@@ -384,10 +372,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "core-foundation"
-version = "0.9.2"
+name = "chrono"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6888e10551bb93e424d8df1d07f1a8b4fceb0001a3a4b048bfc47554946f47b3"
+checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
+dependencies = [
+ "libc",
+ "num-integer",
+ "num-traits",
+ "serde",
+ "time 0.1.44",
+ "winapi",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -400,35 +402,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
-name = "crc32fast"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
-name = "crossbeam-channel"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c02a4d71819009c192cf4872265391563fd6a84c81ff2c0f2a7026ca4c1d85c"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ff1f980957787286a554052d03c7aee98d99cc32e09f6d45f0a814133c87978"
-dependencies = [
- "cfg-if",
- "once_cell",
-]
-
-[[package]]
 name = "crypteia"
 version = "1.0.0"
 dependencies = [
@@ -436,12 +409,9 @@ dependencies = [
  "aws-config",
  "aws-sdk-ssm",
  "futures",
- "lambda_extension",
- "lambda_runtime",
+ "lambda-extension",
  "libc",
  "redhook",
- "serde",
- "serde_json",
  "tokio",
 ]
 
@@ -462,21 +432,11 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "fastrand"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "779d043b6a0b90cc4c0ed7ee380a6504394cee7efd7db050e3774eee387324b2"
+checksum = "c3fcf0cee53519c866c09b5de1f6c56ff9d647101f81c1964fa632e148896cdf"
 dependencies = [
  "instant",
-]
-
-[[package]]
-name = "flate2"
-version = "1.0.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f82b0f4c27ad9f8bfd1f3208d882da2b09c301bc1c828fd3a00d0216d2fbbff6"
-dependencies = [
- "crc32fast",
- "miniz_oxide",
 ]
 
 [[package]]
@@ -585,21 +545,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "getrandom"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi",
-]
-
-[[package]]
 name = "h2"
-version = "0.3.10"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c9de88456263e249e241fcd211d3954e2c9b0ef7ccfc235a444eb367cae3689"
+checksum = "37a82c6d637fc9515a4694bbf1cb2457b79d81ce52b3108bdeea58b07dd34a57"
 dependencies = [
  "bytes",
  "fnv",
@@ -610,29 +559,15 @@ dependencies = [
  "indexmap",
  "slab",
  "tokio",
- "tokio-util 0.6.9",
+ "tokio-util",
  "tracing",
 ]
 
 [[package]]
 name = "hashbrown"
-version = "0.11.2"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
-
-[[package]]
-name = "hdrhistogram"
-version = "7.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31672b7011be2c4f7456c4ddbcb40e7e9a4a9fad8efe49a6ebaf5f307d0109c0"
-dependencies = [
- "base64",
- "byteorder",
- "crossbeam-channel",
- "flate2",
- "nom",
- "num-traits",
-]
+checksum = "db0d4cf898abf0081f964436dc980e96670a0f36863e4b83aaacdb65c9d7ccc3"
 
 [[package]]
 name = "hermit-abi"
@@ -657,7 +592,7 @@ checksum = "75f43d41e26995c17e71ee126451dd3941010b0514a81a9d11f3b341debc2399"
 dependencies = [
  "bytes",
  "fnv",
- "itoa 1.0.1",
+ "itoa",
 ]
 
 [[package]]
@@ -673,9 +608,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.5.1"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acd94fdbe1d4ff688b67b04eee2e17bd50995534a61539e45adfefb45e5e5503"
+checksum = "496ce29bb5a52785b44e0f7ca2847ae0bb839c9bd28f69acac9b99d461c0c04c"
 
 [[package]]
 name = "httpdate"
@@ -685,9 +620,9 @@ checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
 
 [[package]]
 name = "hyper"
-version = "0.14.16"
+version = "0.14.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7ec3e62bdc98a2f0393a5048e4c30ef659440ea6e0e572965103e72bd836f55"
+checksum = "42dc3c131584288d375f2d07f822b0cb012d8c6fb899a5b9fdb3cb7eb9b6004f"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -698,7 +633,7 @@ dependencies = [
  "http-body",
  "httparse",
  "httpdate",
- "itoa 0.4.8",
+ "itoa",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -726,9 +661,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.8.0"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223"
+checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -745,71 +680,37 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "0.4.8"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
-
-[[package]]
-name = "itoa"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
+checksum = "112c678d4050afce233f4f2852bb2eb519230b3cf12f33585275537d7e41578d"
 
 [[package]]
 name = "js-sys"
-version = "0.3.55"
+version = "0.3.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cc9ffccd38c451a86bf13657df244e9c3f37493cce8e5e21e940963777acc84"
+checksum = "c3fac17f7123a73ca62df411b1bf727ccc805daa070338fda671c86dac1bdc27"
 dependencies = [
  "wasm-bindgen",
 ]
 
 [[package]]
-name = "lambda_extension"
-version = "0.1.0"
-source = "git+https://github.com/awslabs/aws-lambda-rust-runtime#917ed63c89a50674397f2fc8be356dedcf168b8b"
-dependencies = [
- "async-stream",
- "bytes",
- "http",
- "hyper",
- "lambda_runtime_api_client 0.4.1",
- "serde",
- "serde_json",
- "tokio",
- "tokio-stream",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "lambda_runtime"
-version = "0.5.1"
+name = "lambda-extension"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c73464e59463e91bf179195a308738477df90240173649d5dd2a1f3a2e4a2d2"
+checksum = "7cd0f503de72d995012c2d7ff6c9d9f0bb0129ae2687b678ddae6d3816930a8c"
 dependencies = [
  "async-stream",
  "bytes",
+ "chrono",
  "http",
  "hyper",
- "lambda_runtime_api_client 0.5.0",
+ "lambda_runtime_api_client",
  "serde",
  "serde_json",
  "tokio",
  "tokio-stream",
  "tower",
  "tracing",
-]
-
-[[package]]
-name = "lambda_runtime_api_client"
-version = "0.4.1"
-source = "git+https://github.com/awslabs/aws-lambda-rust-runtime#917ed63c89a50674397f2fc8be356dedcf168b8b"
-dependencies = [
- "http",
- "hyper",
- "tokio",
- "tower-service",
 ]
 
 [[package]]
@@ -863,52 +764,27 @@ checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
 name = "memchr"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
-
-[[package]]
-name = "minimal-lexical"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
-name = "miniz_oxide"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f5c75688da582b8ffc1f1799e9db273f32133c49e048f614d22ec3256773ccc"
-dependencies = [
- "adler",
-]
+checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "mio"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "713d550d9b44d89174e066b7a6217ae06234c10cb47819a88290d2b353c31799"
+checksum = "57ee1c23c7c63b0c9250c339ffdc69255f110b298b901b9f6c82547b7b87caaf"
 dependencies = [
  "libc",
  "log",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys",
 ]
 
 [[package]]
-name = "nom"
-version = "7.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8903e5a29a317527874d0402f867152a3d21c908bb0b933e416c65e301d4c36"
-dependencies = [
- "memchr",
- "minimal-lexical",
-]
-
-[[package]]
 name = "num-integer"
-version = "0.1.44"
+version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
+checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
 dependencies = [
  "autocfg",
  "num-traits",
@@ -916,9 +792,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
+checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
 dependencies = [
  "autocfg",
 ]
@@ -930,6 +806,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
 dependencies = [
  "hermit-abi",
+ "libc",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
+dependencies = [
  "libc",
 ]
 
@@ -996,9 +881,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e280fbe77cc62c91527259e9442153f4688736748d24660126286329742b4c6c"
+checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
 
 [[package]]
 name = "pin-utils"
@@ -1007,57 +892,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
-name = "ppv-lite86"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
-
-[[package]]
 name = "proc-macro2"
-version = "1.0.39"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c54b25569025b7fc9651de43004ae593a75ad88543b17178aa5e1b9c4f15f56f"
+checksum = "dd96a1e8ed2596c337f8eae5f24924ec83f5ad5ab21ea8e455d3566c69fbcaf7"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.14"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47aa80447ce4daf1717500037052af176af5d38cc3e571d9ec1c7353fc10c87d"
+checksum = "3bcdf212e9776fbcb2d23ab029360416bb1706b1aea2d1a5ba002727cbcab804"
 dependencies = [
  "proc-macro2",
-]
-
-[[package]]
-name = "rand"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
-dependencies = [
- "libc",
- "rand_chacha",
- "rand_core",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
-dependencies = [
- "getrandom",
 ]
 
 [[package]]
@@ -1071,9 +920,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.10"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
+checksum = "62f25bc4c7e55e0b0b7a1d43fb893f4fa1361d0abe38b9ce4f323c2adfe6ef42"
 dependencies = [
  "bitflags",
 ]
@@ -1146,18 +995,18 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
+checksum = "f3f6f92acf49d1b98f7a81226834412ada05458b7364277387724a237f062695"
 
 [[package]]
 name = "schannel"
-version = "0.1.19"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f05ba609c234e60bee0d547fe94a4c7e9da733d1c962cf6e59efa4cd9c8bc75"
+checksum = "88d6731146462ea25d9244b2ed5fd1d716d25c52e4d54aa4fb0f3c4e9854dbe2"
 dependencies = [
  "lazy_static",
- "winapi",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1178,9 +1027,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.5.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d09d3c15d814eda1d6a836f2f2b56a6abc1446c8a34351cb3180d3db92ffe4ce"
+checksum = "2dc14f172faf8a0194a3aded622712b0de276821addc574fa54fc0a1167e10dc"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -1191,9 +1040,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.5.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e90dd10c41c6bfc633da6e0c659bd25d31e0791e5974ac42970267d59eba87f7"
+checksum = "0160a13a177a45bfb43ce71c01580998474f556ad854dcbca936dd2841a5c556"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -1201,9 +1050,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.4"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "568a8e6258aa33c13358f81fd834adb854c6f7c9468520910a9b1e8fac068012"
+checksum = "a41d061efea015927ac527063765e73601444cdc344ba855bc7bd44578b25e1c"
 
 [[package]]
 name = "serde"
@@ -1231,7 +1080,7 @@ version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b7ce2b32a1aed03c558dc61a5cd328f15aff2dbc17daad8fb8af04d2100e15c"
 dependencies = [
- "itoa 1.0.1",
+ "itoa",
  "ryu",
  "serde",
 ]
@@ -1247,15 +1096,15 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9def91fd1e018fe007022791f865d0ccc9b3a0d5001e01aabb8b40e46000afb5"
+checksum = "eb703cfe953bccee95685111adeedb76fabe4e97549a58d16f03ea7b9367bb32"
 
 [[package]]
 name = "smallvec"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
+checksum = "cc88c725d61fc6c3132893370cac4a0200e3fedf5da8331c570664b1987f5ca2"
 
 [[package]]
 name = "socket2"
@@ -1275,9 +1124,9 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "syn"
-version = "1.0.96"
+version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0748dd251e24453cb8717f0354206b91557e4ec8703673a4b30208f2abaf1ebf"
+checksum = "c50aef8a904de4c23c788f104b7dddc7d6f79c647c7c8ce4cc8f73eb0ca773dd"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1286,11 +1135,23 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.5"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41effe7cfa8af36f439fac33861b66b049edc6f9a32331e2312660529c1c24ad"
+checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
 dependencies = [
  "libc",
+ "wasi 0.10.0+wasi-snapshot-preview1",
+ "winapi",
+]
+
+[[package]]
+name = "time"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72c91f41dcb2f096c05f0873d667dceec1087ce5bcf984ec8ffb19acddbb3217"
+dependencies = [
+ "libc",
+ "num_threads",
 ]
 
 [[package]]
@@ -1315,9 +1176,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b557f72f448c511a979e2564e55d74e6c4432fc96ff4f6241bc6bded342643b7"
+checksum = "9724f9a975fb987ef7a3cd9be0350edcbe130698af5b8f7a631e23d42d052484"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1337,25 +1198,11 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50145484efff8818b5ccd256697f36863f587da82cf8b409c53adf1e840798e3"
+checksum = "df54d54117d6fdc4e4fea40fe1e4e566b3505700e148a6827e59b34b0d2600d9"
 dependencies = [
  "futures-core",
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
-name = "tokio-util"
-version = "0.6.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e99e1983e5d376cd8eb4b66604d2e99e79f5bd988c3055891dcd8c9e2604cc0"
-dependencies = [
- "bytes",
- "futures-core",
- "futures-sink",
- "log",
  "pin-project-lite",
  "tokio",
 ]
@@ -1371,24 +1218,20 @@ dependencies = [
  "futures-sink",
  "pin-project-lite",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
 name = "tower"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a89fd63ad6adf737582df5db40d286574513c69a11dac5214dc3b5603d6713e"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
 dependencies = [
  "futures-core",
  "futures-util",
- "hdrhistogram",
- "indexmap",
  "pin-project",
  "pin-project-lite",
- "rand",
- "slab",
  "tokio",
- "tokio-util 0.7.3",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -1402,15 +1245,15 @@ checksum = "343bc9466d3fe6b0f960ef45960509f84480bf4fd96f92901afe7ff3df9d3a62"
 
 [[package]]
 name = "tower-service"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
+checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tracing"
-version = "0.1.29"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "375a639232caf30edfc78e8d89b2d4c375515393e7af7e16f01cd96917fb2105"
+checksum = "a400e31aa60b9d44a52a8ee0343b5b18566b03a8321e0d321f695cf56e940160"
 dependencies = [
  "cfg-if",
  "log",
@@ -1421,9 +1264,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.18"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f480b8f81512e825f337ad51e94c1eb5d3bbdf2b363dcd01e2b19a9ffe3f8e"
+checksum = "cc6b8ad3567499f98a1db7a752b07a7c8c7c7c34c332ec00effb2b0027974b7c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1432,11 +1275,11 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.21"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f4ed65637b8390770814083d20756f87bfa2c21bf2f110babdc5438351746e4"
+checksum = "7b7358be39f2f274f322d2aaed611acc57f382e8eb1e5b48cb9ae30933495ce7"
 dependencies = [
- "lazy_static",
+ "once_cell",
 ]
 
 [[package]]
@@ -1475,15 +1318,21 @@ dependencies = [
 
 [[package]]
 name = "wasi"
+version = "0.10.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
+
+[[package]]
+name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.78"
+version = "0.2.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "632f73e236b219150ea279196e54e610f5dbafa5d61786303d4da54f84e47fce"
+checksum = "7c53b543413a17a202f4be280a7e5c62a1c69345f5de525ee64f8cfdbc954994"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -1491,9 +1340,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.78"
+version = "0.2.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a317bf8f9fba2476b4b2c85ef4c4af8ff39c3c7f0cdfeed4f82c34a880aa837b"
+checksum = "5491a68ab4500fa6b4d726bd67408630c3dbe9c4fe7bda16d5c82a1fd8c7340a"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -1506,9 +1355,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.78"
+version = "0.2.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d56146e7c495528bf6587663bea13a8eb588d39b36b679d83972e1a2dbbdacf9"
+checksum = "c441e177922bc58f1e12c022624b6216378e5febc2f0533e41ba443d505b80aa"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1516,9 +1365,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.78"
+version = "0.2.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7803e0eea25835f8abdc585cd3021b3deb11543c6fe226dcd30b228857c5c5ab"
+checksum = "7d94ac45fcf608c1f45ef53e748d35660f168490c10b23704c7779ab8f5c3048"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1529,15 +1378,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.78"
+version = "0.2.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0237232789cf037d5480773fe568aac745bfe2afbc11a863e97901780a6b47cc"
+checksum = "6a89911bd99e5f3659ec4acf9c4d93b0a90fe4a2a11f15328472058edc5261be"
 
 [[package]]
 name = "web-sys"
-version = "0.3.55"
+version = "0.3.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38eb105f1c59d9eaa6b5cdc92b859d85b926e82cb2e0945cd0c9259faa6fe9fb"
+checksum = "2fed94beee57daf8dd7d51f2b15dc2bcde92d7a72304cdf662a4371008b71b90"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1626,6 +1475,6 @@ checksum = "114ba2b24d2167ef6d67d7d04c8cc86522b87f490025f39f0303b7db5bf5e3d8"
 
 [[package]]
 name = "zeroize"
-version = "1.5.0"
+version = "1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc222aec311c323c717f56060324f32b82da1ce1dd81d9a09aa6a9030bfe08db"
+checksum = "94693807d016b2f2d2e14420eb3bfcca689311ff775dcf113d74ea624b7cdf07"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,12 +15,9 @@ crate_type = ["cdylib"]
 anyhow = "1.0.57"
 tokio = { version = "1.19.2", features = ["full"] }
 futures = { version = "0.3.21" }
-serde = { version = "1.0.137", features = ["derive"] }
-serde_json = "1.0.81"
-aws-config = "0.13.0"
-aws-sdk-ssm = "0.13.0"
-lambda_runtime = "0.5.1"
-lambda_extension = { git = "https://github.com/awslabs/aws-lambda-rust-runtime" }
+aws-config = "0.14.0"
+aws-sdk-ssm = "0.14.0"
+lambda-extension = "0.5.0"
 # lib
 redhook = "2.0"
 libc = "0.2.126"

--- a/README.md
+++ b/README.md
@@ -2,38 +2,115 @@
 
 [![Actions Status](https://github.com/customink/crypteia/actions/workflows/test.yml/badge.svg)](https://github.com/customink/crypteia/actions/workflows/test.yml)
 
-# Crypteia
+# 🛡 Crypteia
 
-## Lambda Extension for Secure SSM Parameters as Environment Variables
+## Rust Lambda Extension for any Runtime to preload SSM Parameters as Secure Environment Variables!
 
-To-Do List:
+Super fast and only performaned once during your function's initialization, Crypteia turns your serverless YAML from this:
 
-- Huge thanks to this guy! https://github.com/jakejscott/rust-parameters-lambda-extension/issues/1
-- Ensure lambda lifecycle events correct. Witnessed shutdown errors. Maybe we need some invoke hook to make sure SSM finished work?
-- Make sure dev containers work locally with VS Code Remote Development. Add docs below.
-- Set raw environment variables.
-- Maybe rename to something like cold environments?
+```yaml
+Environment:
+  Variables:
+    SECRET: x-crypteia-ssm:/myapp/SECRET
+```
 
-## Development Environment
+Into real runtime (no matter the lang) environment variables backed by SSM Parameter Store. For example, assuming the SSM Parameter path above returns `1A2B3C4D5E6F` as the value. Your code would return:
 
-Using Codespaces or VS Code Remote Containers...
+```javascript
+process.env.SECRET; // 1A2B3C4D5E6F
+```
+
+```ruby
+ENV['SECRET'] # 1A2B3C4D5E6F
+```
+
+We do this using our lib via `LD_PRELOAD` with [redhook](https://github.com/geofft/redhook) in coordination with our [Lambda Extension](https://docs.aws.amazon.com/lambda/latest/dg/runtimes-extensions-api.html) binary. See installation & usage sections for more details.
+
+💕 Many thanks to the following projects & people for their work, code, and personal help that made Crypteia possible:
+
+- **[Hunter Madison](https://github.com/hmadison)**: Who taught me about how to use redhook based on Michele Mancioppi's [opentelemetry-injector](https://github.com/mmanciop/opentelemetry-injector) project.
+- **[Jake Scott](https://github.com/jakejscott)**: And his [rust-parameters-lambda-extension](https://github.com/jakejscott/rust-parameters-lambda-extension) project which served as the starting point for this project.
+
+## Installation
+
+🚧 🚧 🚧 TODO: Installation instructions for both `crypteia` binary extensions and `libcrypteia.so` file via `LD_PRELOAD`...
+
+## Usage
+
+First, you will need your secret environment variables setup in [AWS Systems Manager Parameter Store](https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-parameter-store.html). These can be whatever [hierarchy](https://docs.aws.amazon.com/systems-manager/latest/userguide/sysman-paramstore-hierarchies.html) you choose. Parameters can be any string type. However, we recommend using `SecureString` to ensure your secrets are encrypted within AWS. For example, let's assume the following paramter paths and values exists.
+
+- `/myapp/SECRET` -> `1A2B3C4D5E6F`
+- `/myapp/access-key` -> `G7H8I9J0K1L2`
+- `/myapp/envs/DB_URL` -> `mysql2://u:p@host:3306`
+- `/myapp/envs/NR_KEY` -> `z6y5x4w3v2u1`
+
+Crypteia supports two methods to fetch SSM parameters:
+
+1. `x-crypteia-ssm:` - Single path for a single environment variable.
+2. `x-crypteia-ssm-path:` - Path prefix to fetch many environment variables.
+
+Using whatever serverless framework you prefer, setup your function's environment variables using either of the two SSM interfaces from above. For example, here is a environment variables section for an [AWS SAM](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-getting-started.html) template that demonstrates all of Crypteia's features.
+
+```yaml
+Environment:
+  Variables:
+    SECRET: x-crypteia-ssm:/myapp/SECRET
+    ACCESS_KEY: x-crypteia-ssm:/myapp/access-key
+    X_CRYPTEIA_SSM: x-crypteia-ssm-path:/myapp/envs
+    DB_URL: x-crypteia
+    NR_KEY: x-crypteia
+```
+
+When your function initializes, each of the four environmet variables (`SECRET`, `ACCESS_KEY`, `DB_URL`, and `NR_KEY`) will return values from their respective SSM paths.
+
+```
+process.env.SECRET;       // 1A2B3C4D5E6F
+process.env.ACCESS_KEY;   // G7H8I9J0K1L2
+process.env.DB_URL;       // mysql2://u:p@host:3306
+process.env.NR_KEY;       // z6y5x4w3v2u1
+```
+
+Here are a few details about the internal implementation on how Crypteia works:
+
+1. When accessing a single parameter path via `x-crypteia-ssm:` the environment variable name available to your runtime is used as is. No part of the parameter path effects the resulting name.
+2. When using `x-crypteia-ssm-path:` the environment variable name can be anything and the value is left unchanged.
+3. The parameter path hierarchy passed with `x-crypteia-ssm-path:` must be one level deep and end with valid environment variable names. These names must match environement placeholders using `x-crypteia` values.
+
+For security, the usage of `DB_URL: x-crypteia` placeholders ensures that your application's configuration is in full control on which dynamic values can be used with `x-crypteia-ssm-path:`.
+
+#### IAM Permissions
+
+Please use AWS' [Restricting access to Systems Manager parameters using IAM policies](https://docs.aws.amazon.com/systems-manager/latest/userguide/sysman-paramstore-access.html) guide for details on what policies your function's IAM Role will need. For an appliction to pull both single parameters as well as bulk paths, I have found the following policy helpful. It assumed the `/myapp` prefix and using AWS default KMS encryption key.
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "ssm:GetParameter",
+        "ssm:GetParametersByPath",
+        "ssm:GetParameters",
+        "ssm:GetParameterHistory",
+        "ssm:DescribeParameters"
+      ],
+      "Resource": "arn:aws:ssm:us-east-1:123456789012:parameter/myapp*",
+      "Effect": "Allow"
+    },
+    {
+      "Action": "kms:Decrypt",
+      "Resource": "arn:aws:kms:us-east-1:123456789012:key/4914ec06-e888-4ea5-a371-5b88eEXAMPLE",
+      "Effect": "Allow"
+    }
+  ]
+}
+```
+
+## Development
+
+🚧 🚧 🚧 TODO: Talk more about Codespaces or VS Code Remote Containers...
 
 - https://github.com/microsoft/vscode-remote-try-rust
 - https://github.com/microsoft/vscode-dev-containers/tree/main/containers/rust/history
 
-# Building
-
-```sh
-./build.sh
-```
-
-# Usage
-
-```shell
-FOO_PARAM=ssm_parameter:/my/parameter
-FOO_PARAM=my-parameter
-```
-
-```shell
-FOO_PARAMS=ssm_parameters:/my/path/envs
-```
+🚧 🚧 🚧 TODO: Speak to commands and running tests.

--- a/bin/test
+++ b/bin/test
@@ -4,5 +4,4 @@ set -e
 cargo test
 
 ./bin/build
-
 ./test/libcrypteia.sh 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 extern crate libc;
 use libc::c_char;
+use std::collections::HashMap;
 use std::ffi::CStr;
 use std::ffi::CString;
 use std::sync::Once;
@@ -19,16 +20,28 @@ redhook::hook! {
                 println!("[crypteia] Initialized libcrypteia using LD_PRELOAD");
             }
         });
-        let original_value = redhook::real!(getenv)(name);
-        if original_value.is_null() {
-            return original_value;
+        let env_value = redhook::real!(getenv)(name);
+        if env_value.is_null() {
+            return env_value;
         }
-        let given_name = CStr::from_ptr(name).to_str().unwrap();
-        if given_name == "HELLO" {
-            // https://doc.rust-lang.org/std/ffi/struct.CStr.html#method.as_ptr
-            let result = CString::new("WORLD").unwrap();
-            return result.into_raw();
+        let name_str = CStr::from_ptr(name).to_str().unwrap();
+        let name_string = name_str.to_string();
+        // TODO: Replace this with a shared data structure from binary.
+        let crypteia_envs: HashMap<String, String> = HashMap::from([
+            ("SECRET".to_string(), "1A2B3C4D5E6F".to_string()),
+        ]);
+        if crypteia_envs.contains_key(&name_string) {
+            let env_value_str = CStr::from_ptr(env_value).to_str().unwrap();
+            let env_value_string = env_value_str.to_string();
+            if env_value_string.starts_with("x-crypteia") {
+                let crypteia_value = crypteia_envs.get(&name_string).unwrap().clone();
+                let crypteia_value_c_string = CString::new(crypteia_value).unwrap();
+                crypteia_value_c_string.into_raw()
+            } else {
+                env_value
+            }
+        } else {
+            env_value
         }
-        original_value
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,17 +1,15 @@
 mod ssm;
-use lambda_extension::{extension_fn, Error, LambdaEvent, NextEvent};
-use serde_json::json;
+use lambda_extension::{service_fn, Error, LambdaEvent, NextEvent};
 use std::collections::HashMap;
 
 #[tokio::main]
 async fn main() -> Result<(), Error> {
-    println!("[crypteia] init");
-    let vars: HashMap<String, String> = std::env::vars().collect();
-    let config = aws_config::load_from_env().await;
-    let ssm_client: aws_sdk_ssm::Client = aws_sdk_ssm::Client::new(&config);
-    let parameters = ssm::fetch_parameters(vars, &ssm_client).await.unwrap();
-    println!("[crypteia] fetched: {}", json!(&parameters));
-    let func = extension_fn(parameters_extension);
+    println!("[crypteia] Init");
+    let env_vars: HashMap<String, String> = std::env::vars().collect();
+    // TODO: Pass this data structure to the shared object library somehow.
+    let _parameters = ssm::get_envs(env_vars).await.unwrap();
+    println!("[crypteia] Fetched environment variables");
+    let func = service_fn(parameters_extension);
     lambda_extension::run(func).await
 }
 

--- a/src/ssm.rs
+++ b/src/ssm.rs
@@ -1,150 +1,114 @@
 use anyhow::Result;
 use futures::future::join_all;
-use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use tokio::{spawn, task::JoinHandle};
 
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
-pub struct Parameter {
-    pub name: String,
-    pub args: String,
-    pub items: Vec<ParameterItem>,
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
-pub struct ParameterItem {
-    pub name: String,
-    pub value: String,
-}
-
-pub async fn ssm_get_parameter(
-    ssm: &aws_sdk_ssm::Client,
-    name: String,
-    args: String,
-) -> Result<Parameter> {
-    let mut items: Vec<ParameterItem> = Vec::new();
-
-    let response = ssm
-        .get_parameter()
-        .name(args.replace("ssm_parameter:", ""))
-        .with_decryption(true)
-        .send()
-        .await;
-
-    match response {
-        Ok(response) => {
-            if let Some(parameter) = response.parameter {
-                items.push(ParameterItem {
-                    name: parameter.name.expect("name is required"),
-                    value: parameter.value.expect("value is required"),
-                });
-            }
-        }
-        Err(error) => {
-            eprintln!(
-                "[crypteia] Error calling ssm:GetParameter. Environment variable: {name} Args: {args} Error: {err}",
-                err = error
-            );
-        }
-    }
-
-    Ok(Parameter {
-        name: name.to_owned(),
-        args: args.to_owned(),
-        items,
-    })
-}
-
-pub async fn ssm_get_parameters_by_path(
-    ssm: &aws_sdk_ssm::Client,
-    name: String,
-    args: String,
-) -> Result<Parameter> {
-    let mut items: Vec<ParameterItem> = Vec::new();
-
-    let mut token: Option<String> = None;
-
-    loop {
-        let response = ssm
-            .get_parameters_by_path()
-            .path(args.replace("ssm_parameters:", ""))
-            .recursive(true)
-            .with_decryption(true)
-            .set_next_token(token.clone())
-            .send()
-            .await;
-
-        match response {
-            Ok(response) => {
-                if let Some(parameters) = response.parameters {
-                    for parameter in parameters {
-                        items.push(ParameterItem {
-                            name: parameter.name.expect("name is required"),
-                            value: parameter.value.expect("value is required"),
-                        });
-                    }
-                }
-
-                if response.next_token == None {
-                    break;
-                }
-
-                token = response.next_token;
-            }
-            Err(error) => {
-                eprintln!(
-                    "[crypteia] Error calling ssm:GetParametersByPath. Environment variable: {name} Args: {args} Error: {err}",
-                    err = error
-                );
-                break;
-            }
-        }
-    }
-
-    Ok(Parameter {
-        name: name.to_owned(),
-        args: args.to_owned(),
-        items,
-    })
-}
-
-pub async fn fetch_parameters(
-    vars: HashMap<String, String>,
-    ssm: &aws_sdk_ssm::Client,
-) -> Result<Vec<Parameter>> {
-    let mut results: Vec<Parameter> = Vec::new();
-
-    let mut handles: Vec<JoinHandle<Result<Parameter>>> = Vec::new();
-
-    for (name, args) in vars {
-        if args.starts_with("ssm_parameter:") {
-            let ssm_clone = ssm.clone();
+pub async fn get_envs(env_vars: HashMap<String, String>) -> Result<HashMap<String, String>> {
+    let sdk_config = aws_config::load_from_env().await;
+    let ssm_client: aws_sdk_ssm::Client = aws_sdk_ssm::Client::new(&sdk_config);
+    let mut results: HashMap<String, String> = HashMap::new();
+    let mut handles: Vec<JoinHandle<Result<HashMap<String, String>>>> = Vec::new();
+    for (name, path) in env_vars {
+        if path.starts_with("x-crypteia-ssm:") {
+            let ssm_clone = ssm_client.clone();
             handles.push(spawn(async move {
-                ssm_get_parameter(&ssm_clone, name, args).await
+                ssm_get_parameter(&ssm_clone, name, path).await
             }));
-        } else if args.starts_with("ssm_parameters:") {
-            let ssm_clone = ssm.clone();
+        } else if path.starts_with("x-crypteia-ssm-path:") {
+            let ssm_clone = ssm_client.clone();
             handles.push(spawn(async move {
-                ssm_get_parameters_by_path(&ssm_clone, name, args).await
+                ssm_get_parameters_by_path(&ssm_clone, name, path).await
             }));
         }
     }
-
     let tasks = join_all(handles).await;
-
     for task in tasks {
         match task {
             Ok(result) => match result {
                 Ok(parameter) => {
-                    results.push(parameter);
+                    parameter.into_iter().for_each(|(key, value)| {
+                        results.insert(key, value);
+                    });
                 }
                 Err(error) => eprintln!("[crypteia] Parameter error {err}", err = error),
             },
             Err(error) => eprintln!("[crypteia] JoinError {err}", err = error),
         }
     }
-
     Ok(results)
+}
+
+async fn ssm_get_parameter(
+    ssm: &aws_sdk_ssm::Client,
+    name: String,
+    path: String,
+) -> Result<HashMap<String, String>> {
+    let mut items: HashMap<String, String> = HashMap::new();
+    let response = ssm
+        .get_parameter()
+        .name(path.replace("x-crypteia-ssm:", ""))
+        .with_decryption(true)
+        .send()
+        .await;
+    match response {
+        Ok(response) => {
+            if let Some(parameter) = response.parameter {
+                items.insert(name, parameter.value.unwrap());
+            }
+        }
+        Err(error) => {
+            eprintln!(
+                "[crypteia] Error calling ssm:GetParameter. Environment variable: {name} Path: {path} Error: {err}",
+                err = error
+            );
+        }
+    }
+    Ok(items)
+}
+
+async fn ssm_get_parameters_by_path(
+    ssm: &aws_sdk_ssm::Client,
+    name: String,
+    path: String,
+) -> Result<HashMap<String, String>> {
+    let mut items: HashMap<String, String> = HashMap::new();
+    let mut token: Option<String> = None;
+    loop {
+        let ssm_path = path.replace("x-crypteia-ssm-path:", "");
+        let response = ssm
+            .get_parameters_by_path()
+            .path(ssm_path.clone())
+            .recursive(true)
+            .with_decryption(true)
+            .set_next_token(token.clone())
+            .send()
+            .await;
+        match response {
+            Ok(response) => {
+                if let Some(parameters) = response.parameters {
+                    for parameter in parameters {
+                        let path_prefix = parameter.name.unwrap();
+                        let ssm_clone = ssm_path.clone();
+                        let ssm_path_replace = ssm_clone + "/";
+                        let env_name = path_prefix.replace(ssm_path_replace.as_str(), "");
+                        items.insert(env_name, parameter.value.unwrap());
+                    }
+                }
+                if response.next_token == None {
+                    break;
+                }
+                token = response.next_token;
+            }
+            Err(error) => {
+                eprintln!(
+                    "[crypteia] Error calling ssm:GetParametersByPath. Environment variable: {name} Path: {path} Error: {err}",
+                    err = error
+                );
+                break;
+            }
+        }
+    }
+    Ok(items)
 }
 
 #[cfg(test)]
@@ -152,55 +116,68 @@ mod test {
     use super::*;
     use anyhow::Result;
     use aws_sdk_ssm::model::ParameterType;
-    use serde_json::json;
 
     #[tokio::test]
     async fn should_parse() -> Result<()> {
-        let config = aws_config::load_from_env().await;
-        let ssm = aws_sdk_ssm::Client::new(&config);
-
-        ssm.put_parameter()
-            .name("/crypteia/parameter".to_owned())
-            .value("my-parameter".to_owned())
+        let sdk_config = aws_config::load_from_env().await;
+        let ssm_client = aws_sdk_ssm::Client::new(&sdk_config);
+        ssm_client
+            .put_parameter()
+            .name("/crypteia/v5/myapp/SECRET".to_owned())
+            .value("1A2B3C4D5E6F".to_owned())
             .r#type(ParameterType::SecureString)
             .overwrite(true)
             .send()
             .await?;
-
-        ssm.put_parameter()
-            .name("/crypteia/path/prefix/value/1".to_owned())
-            .value("value-1".to_owned())
+        ssm_client
+            .put_parameter()
+            .name("/crypteia/v5/myapp/access-key".to_owned())
+            .value("G7H8I9J0K1L2".to_owned())
             .r#type(ParameterType::SecureString)
             .overwrite(true)
             .send()
             .await?;
-
-        ssm.put_parameter()
-            .name("/crypteia/path/prefix/value/2".to_owned())
-            .value("value-2".to_owned())
+        ssm_client
+            .put_parameter()
+            .name("/crypteia/v5/myapp/envs/DB_URL".to_owned())
+            .value("mysql2://u:p@host:3306".to_owned())
             .r#type(ParameterType::SecureString)
             .overwrite(true)
             .send()
             .await?;
-
-        let vars: HashMap<String, String> = HashMap::from([
+        ssm_client
+            .put_parameter()
+            .name("/crypteia/v5/myapp/envs/NR_KEY".to_owned())
+            .value("z6y5x4w3v2u1".to_owned())
+            .r#type(ParameterType::SecureString)
+            .overwrite(true)
+            .send()
+            .await?;
+        let env_vars: HashMap<String, String> = HashMap::from([
+            ("EXISTING".to_string(), "existingvalue".to_string()),
             (
-                "FOO_PARAM".to_string(),
-                "ssm_parameter:/crypteia/parameterx".to_string(),
+                "SECRET".to_string(),
+                "x-crypteia-ssm:/crypteia/v5/myapp/SECRET".to_string(),
             ),
             (
-                "FOO_PARAMS".to_string(),
-                "ssm_parameters:/crypteia/path/prefixx".to_string(),
+                "ACCESS_KEY".to_string(),
+                "x-crypteia-ssm:/crypteia/v5/myapp/access-key".to_string(),
             ),
+            (
+                "X_CRYPTEIA_SSM".to_string(),
+                "x-crypteia-ssm-path:/crypteia/v5/myapp/envs".to_string(),
+            ),
+            ("DB_URL".to_string(), "x-crypteia".to_string()),
+            ("NR_KEY".to_string(), "x-crypteia".to_string()),
         ]);
-
-        let results = fetch_parameters(vars, &ssm)
-            .await
-            .expect("Should fetch parameters");
-
-        let json = json!(&results);
-        println!("Parameters {}", json);
-
+        let expected: HashMap<String, String> = HashMap::from([
+            ("SECRET".to_string(), "1A2B3C4D5E6F".to_string()),
+            ("ACCESS_KEY".to_string(), "G7H8I9J0K1L2".to_string()),
+            ("DB_URL".to_string(), "mysql2://u:p@host:3306".to_string()),
+            ("NR_KEY".to_string(), "z6y5x4w3v2u1".to_string()),
+        ]);
+        let results = get_envs(env_vars).await.expect("Should fetch parameters");
+        assert_eq!(results, expected);
         Ok(())
     }
 }

--- a/test/libcrypteia.sh
+++ b/test/libcrypteia.sh
@@ -5,10 +5,16 @@ set -e
 echo "== Testing libcrypteia =="
 
 assert "./test/libcrypteia/existing.sh" \
-       "WORLD"
+       "existingvalue"
 
-# assert "./test/libcrypteia/empty.sh" \
-#        "TEST"
+assert "./test/libcrypteia/override.sh" \
+       "1A2B3C4D5E6F"
+
+assert "./test/libcrypteia/empty.sh" \
+       ""
+
+assert "./test/libcrypteia/fullpath.sh" \
+       "x-crypteia-ssm-path:/crypteia/v5/myapp/envs"
 
 echo "== Testing complete! =="
 

--- a/test/libcrypteia/fullpath.sh
+++ b/test/libcrypteia/fullpath.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 
-export EXISTING=existingvalue
+export X_CRYPTEIA_SSM=x-crypteia-ssm-path:/crypteia/v5/myapp/envs
 export LD_PRELOAD="${LD_PRELOAD:=/workspaces/crypteia/target/release/libcrypteia.so}"
 
-ruby -e "puts(ENV['EXISTING'])"
+ruby -e "puts(ENV['X_CRYPTEIA_SSM'])"

--- a/test/libcrypteia/override.sh
+++ b/test/libcrypteia/override.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 
-export EXISTING=existingvalue
+export SECRET=x-crypteia-ssm:/crypteia/v5/myapp/SECRET
 export LD_PRELOAD="${LD_PRELOAD:=/workspaces/crypteia/target/release/libcrypteia.so}"
 
-ruby -e "puts(ENV['EXISTING'])"
+ruby -e "puts(ENV['SECRET'])"


### PR DESCRIPTION
This work does a lot of work but is primarily meant to address #7 by providing a base simple HashMap interface rather than the old format which leveraged an internal HTTP server interface for the Runtime. Here are a few other things this pull request does:

- Lots of documentation. Call outs for missing sections.
- Clean up crates. Update new AWS SDK. Removed runtime. Use crate for lambda extension.
- Prepare for work needed in #4 to share parameter -> env hash.