### PR TITLE
Use GitHub Container as Extension Installation.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Build & Run Development Container
         uses: devcontainers/ci@v0.2
         with:
-          imageName: ghcr.io/customink/crypteia
+          imageName: ghcr.io/customink/crypteia-devcontainer
           runCmd: |
             ./bin/setup
             ./amzn/setup
@@ -46,3 +46,9 @@ jobs:
           prerelease: ${{ steps.changelog_reader.outputs.status == 'prereleased' }}
           draft: ${{ steps.changelog_reader.outputs.status == 'unreleased' }}
           token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Push Lambda Extension Layer Image
+        env:
+          CRYPTEIA_VERSION: ${{ steps.changelog_reader.outputs.version }}
+        run: |
+          echo "${{ secrets.PUBLIC_GITHUB_TOKEN_PACKAGES }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+          ./layer/deploy-image

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
             AWS_SESSION_TOKEN
             AWS_DEFAULT_REGION
             AWS_REGION
-          imageName: ghcr.io/customink/crypteia
+          imageName: ghcr.io/customink/crypteia-devcontainer
           runCmd: |
             ./bin/setup
             ./bin/test
@@ -40,7 +40,7 @@ jobs:
             AWS_SESSION_TOKEN
             AWS_DEFAULT_REGION
             AWS_REGION
-          imageName: ghcr.io/customink/crypteia
+          imageName: ghcr.io/customink/crypteia-devcontainer
           runCmd: |
             ./amzn/setup
             ./amzn/test

--- a/layer/Dockerfile
+++ b/layer/Dockerfile
@@ -1,0 +1,8 @@
+FROM alpine
+LABEL org.opencontainers.image.source "https://github.com/customink/crypteia"
+LABEL org.opencontainers.image.description "Rust Lambda Extension for any Runtime to preload SSM Parameters as Secure Environment Variables!"
+
+RUN mkdir -p /opt/lib
+RUN mkdir -p /opt/extensions
+COPY ./build/crypteia-amzn /opt/extensions/crypteia
+COPY ./build/libcrypteia-amzn.so /opt/lib/libcrypteia.so

--- a/layer/deploy-image
+++ b/layer/deploy-image
@@ -1,0 +1,15 @@
+#!/bin/sh
+set -e
+
+if [ -z "${CRYPTEIA_VERSION}" ]; then
+  echo "CRYPTEIA_VERSION is not set"
+  exit 1
+fi
+
+TAG="ghcr.io/customink/crypteia-extension:${CRYPTEIA_VERSION}"
+
+echo "== [Lambda Extension Image] building... =="
+docker build --tag $TAG --file layer/Dockerfile .
+
+echo "== [Lambda Extension Image] push... =="
+docker push $TAG


### PR DESCRIPTION
The purpose of this pull request is to provide a simple interface to install the Lambda Extension for Lambda Containers. This post here (https://aws.amazon.com/blogs/compute/working-with-lambda-layers-and-extensions-in-container-images/) does a great job outlining the technique. The learnings here will influence an another open-source project to use Libvips with Ruby here (https://github.com/customink/ruby-vips-lambda).

@brcarp I will be making some ℹ️ comments on various parts of this and merging right away. Feel free to ask questions tho and see what eventually lands in main after the merge.

```dockerfile
FROM public.ecr.aws/myrepo/shared-lib-layer:1 AS shared-lib-layer
WORKDIR /opt
COPY --from=shared-lib-layer /opt/ .
```

## Post Merge TODO

- Ensure extension package is public.
- Test container extension usage and update readme.
