### PR TITLE
Build package/opt Directory. DRY Usage.

### DIFF
--- a/bin/build-arch
+++ b/bin/build-arch
@@ -26,6 +26,5 @@ cd ..
 rm -rf ./package/opt
 mkdir -p ./package/opt/extensions
 mkdir -p ./package/opt/lib
-cp ./build/crypteia-amzn ./package/opt/extensions/crypteia
-cp ./build/libcrypteia-amzn.so ./package/opt/lib/libcrypteia.so
-
+cp "./build/crypteia-${BUILD_ARCH}" ./package/opt/extensions/crypteia
+cp "./build/libcrypteia-${BUILD_ARCH}.so" ./package/opt/lib/libcrypteia.so

--- a/bin/build-arch
+++ b/bin/build-arch
@@ -22,3 +22,10 @@ chmod +x "$BIN"
 zip -r "${BIN}.zip" "$BIN"
 zip -r "libcrypteia-${BUILD_ARCH}.zip" "$LIB"
 cd ..
+
+rm -rf ./package/opt
+mkdir -p ./package/opt/extensions
+mkdir -p ./package/opt/lib
+cp ./build/crypteia-amzn ./package/opt/extensions/crypteia
+cp ./build/libcrypteia-amzn.so ./package/opt/lib/libcrypteia.so
+

--- a/package/Dockerfile-amzn
+++ b/package/Dockerfile-amzn
@@ -1,8 +1,4 @@
 FROM alpine
 LABEL org.opencontainers.image.source "https://github.com/customink/crypteia"
 LABEL org.opencontainers.image.description "Rust Lambda Extension for any Runtime to preload SSM Parameters as Secure Environment Variables!"
-
-RUN mkdir -p /opt/lib
-RUN mkdir -p /opt/extensions
-COPY ./build/crypteia-amzn /opt/extensions/crypteia
-COPY ./build/libcrypteia-amzn.so /opt/lib/libcrypteia.so
+COPY ./package/opt /opt

--- a/package/Dockerfile-debian
+++ b/package/Dockerfile-debian
@@ -1,8 +1,4 @@
 FROM alpine
 LABEL org.opencontainers.image.source "https://github.com/customink/crypteia"
 LABEL org.opencontainers.image.description "Rust Lambda Extension for any Runtime to preload SSM Parameters as Secure Environment Variables!"
-
-RUN mkdir -p /opt/lib
-RUN mkdir -p /opt/extensions
-COPY ./build/crypteia-debian /opt/extensions/crypteia
-COPY ./build/libcrypteia-debian.so /opt/lib/libcrypteia.so
+COPY ./package/opt /opt

--- a/package/deploy
+++ b/package/deploy
@@ -6,12 +6,6 @@ if [ -z "${S3_BUCKET_NAME}" ]; then
   exit 1
 fi
 
-mkdir -p ./package/opt/extensions
-mkdir -p ./package/opt/lib
-
-cp ./build/crypteia-amzn ./package/opt/extensions/crypteia
-cp ./build/libcrypteia-amzn.so ./package/opt/lib/libcrypteia.so
-
 cd ./package/opt
 zip -r package.zip .
 mv package.zip ..


### PR DESCRIPTION
This helps DRY up the Python docker testing in #19 by making a full package/opt directory to simply copy (or volume share) as needed.