### PR TITLE
Shrink extensions with scratch, add ltrace for dev, and format

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,16 +1,16 @@
 FROM mcr.microsoft.com/vscode/devcontainers/rust
 
-RUN sudo apt-get update -y && \
-    sudo apt-get upgrade -y && \
-    sudo apt-get install zip musl-tools -y
+RUN sudo apt-get update -y \
+    && sudo apt-get upgrade -y \
+    && sudo apt-get install zip musl-tools ltrace -y
 
-RUN rustup update && \
-    rustup target add x86_64-unknown-linux-musl
+RUN rustup update \
+    && rustup target add x86_64-unknown-linux-musl
 
 RUN sudo apt-get install -y nodejs
 
-RUN cd /tmp && \
-    curl -L https://github.com/aws/aws-sam-cli/releases/latest/download/aws-sam-cli-linux-x86_64.zip > aws-sam-cli-linux-x86_64.zip && \
-    unzip aws-sam-cli-linux-x86_64.zip -d sam-installation && \
-    rm -rf aws-sam-cli-linux-x86_64.zip && \
-    sudo ./sam-installation/install
+RUN cd /tmp \
+    && curl -L https://github.com/aws/aws-sam-cli/releases/latest/download/aws-sam-cli-linux-x86_64.zip > aws-sam-cli-linux-x86_64.zip \
+    && unzip aws-sam-cli-linux-x86_64.zip -d sam-installation \
+    && rm -rf aws-sam-cli-linux-x86_64.zip \
+    && sudo ./sam-installation/install

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+ - `ltrace` for debugging
+
+### Changed
+
+ - Use `scratch` base instead of `alpine` for smaller lambda extension images.
+
 ## [0.94.0] - 2022-10-03
 
 Schedule release. No changes.

--- a/package/Dockerfile-amzn
+++ b/package/Dockerfile-amzn
@@ -1,4 +1,4 @@
-FROM alpine
+FROM scratch
 LABEL org.opencontainers.image.source "https://github.com/customink/crypteia"
 LABEL org.opencontainers.image.description "Rust Lambda Extension for any Runtime to preload SSM Parameters as Secure Environment Variables!"
 COPY ./package/opt /opt

--- a/package/Dockerfile-debian
+++ b/package/Dockerfile-debian
@@ -1,4 +1,4 @@
-FROM alpine
+FROM scratch
 LABEL org.opencontainers.image.source "https://github.com/customink/crypteia"
 LABEL org.opencontainers.image.description "Rust Lambda Extension for any Runtime to preload SSM Parameters as Secure Environment Variables!"
 COPY ./package/opt /opt

--- a/test/libcrypteia.sh
+++ b/test/libcrypteia.sh
@@ -14,7 +14,7 @@ echo "============================="
 echo "== Simulating crypteia binary JSON write =="
 echo '{
   "SECRET": "1A2B3C4D5E6F",
-  "ACCESS_KEY": "G7H8I9J0K1L2", 
+  "ACCESS_KEY": "G7H8I9J0K1L2",
   "DB_URL": "mysql2://u:p@host:3306",
   "NR_KEY": "z6y5x4w3v2u1"
 }' > $CRYPTEIA_ENV_FILE
@@ -38,7 +38,7 @@ assert "./test/libcrypteia/_envfile.sh" \
 
 assert "./test/libcrypteia/empty-${TEST_LANG}.sh" \
        "undefined"
-       
+
 assert "./test/libcrypteia/fullpath-${TEST_LANG}.sh" \
        "x-crypteia-ssm-path:/crypteia/v5/myapp/envs" \
        "Because not replaced by a single env var."


### PR DESCRIPTION
This was mostly separated from #19 because some of it seemed unrelated. I can also fold this back into that branch, but thought it might make sense to make these changes separately.

Here we use scratch to make the image for extensions as small as possible. The `ltrace` utility was added for ability to trace shared library calls and there are some minor formatting changes included as well.