### PR TITLE
Fix release workflow: manifest list conflict on major-version arch tags

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,4 +1,4 @@
 FROM scratch
-LABEL org.opencontainers.image.source "https://github.com/rails-lambda/crypteia"
-LABEL org.opencontainers.image.description "Rust Lambda Extension for any Runtime to preload SSM Parameters as Secure Environment Variables!"
+LABEL org.opencontainers.image.source="https://github.com/rails-lambda/crypteia"
+LABEL org.opencontainers.image.description="Rust Lambda Extension for any Runtime to preload SSM Parameters as Secure Environment Variables!"
 COPY ./package/opt /opt

--- a/package/deploy-image-amzn
+++ b/package/deploy-image-amzn
@@ -14,30 +14,28 @@ docker login ghcr.io -u "metaskills" -p $DOCKER_LOGIN_PAT
 BASE_NAME_AMD64="ghcr.io/rails-lambda/crypteia-extension-amzn-amd64"
 docker build \
   --platform linux/amd64 \
-  --tag "${BASE_NAME_AMD64}:${CRYPTEIA_VERSION_MAJOR}" \
   --tag "${BASE_NAME_AMD64}:${CRYPTEIA_VERSION}" \
   --file package/Dockerfile .
-docker push "${BASE_NAME_AMD64}:${CRYPTEIA_VERSION_MAJOR}"
 docker push "${BASE_NAME_AMD64}:${CRYPTEIA_VERSION}"
 
 ./amzn/setup-arm64
 BASE_NAME_ARM64="ghcr.io/rails-lambda/crypteia-extension-amzn-arm64"
 docker build \
   --platform linux/arm64 \
-  --tag "${BASE_NAME_ARM64}:${CRYPTEIA_VERSION_MAJOR}" \
   --tag "${BASE_NAME_ARM64}:${CRYPTEIA_VERSION}" \
   --file package/Dockerfile .
-docker push "${BASE_NAME_ARM64}:${CRYPTEIA_VERSION_MAJOR}"
 docker push "${BASE_NAME_ARM64}:${CRYPTEIA_VERSION}"
 
-docker manifest create \
-  "ghcr.io/rails-lambda/crypteia-extension-amzn:${CRYPTEIA_VERSION_MAJOR}" \
-  --amend "${BASE_NAME_AMD64}:${CRYPTEIA_VERSION_MAJOR}" \
-  --amend "${BASE_NAME_ARM64}:${CRYPTEIA_VERSION_MAJOR}"
-docker manifest push "ghcr.io/rails-lambda/crypteia-extension-amzn:${CRYPTEIA_VERSION_MAJOR}"
-
+docker manifest rm "ghcr.io/rails-lambda/crypteia-extension-amzn:${CRYPTEIA_VERSION}" 2>/dev/null || true
 docker manifest create \
   "ghcr.io/rails-lambda/crypteia-extension-amzn:${CRYPTEIA_VERSION}" \
-  --amend "${BASE_NAME_AMD64}:${CRYPTEIA_VERSION}" \
-  --amend "${BASE_NAME_ARM64}:${CRYPTEIA_VERSION}"
+  "${BASE_NAME_AMD64}:${CRYPTEIA_VERSION}" \
+  "${BASE_NAME_ARM64}:${CRYPTEIA_VERSION}"
 docker manifest push "ghcr.io/rails-lambda/crypteia-extension-amzn:${CRYPTEIA_VERSION}"
+
+docker manifest rm "ghcr.io/rails-lambda/crypteia-extension-amzn:${CRYPTEIA_VERSION_MAJOR}" 2>/dev/null || true
+docker manifest create \
+  "ghcr.io/rails-lambda/crypteia-extension-amzn:${CRYPTEIA_VERSION_MAJOR}" \
+  "${BASE_NAME_AMD64}:${CRYPTEIA_VERSION}" \
+  "${BASE_NAME_ARM64}:${CRYPTEIA_VERSION}"
+docker manifest push "ghcr.io/rails-lambda/crypteia-extension-amzn:${CRYPTEIA_VERSION_MAJOR}"

--- a/package/deploy-image-amzn
+++ b/package/deploy-image-amzn
@@ -10,6 +10,10 @@ CRYPTEIA_VERSION_MAJOR=$(echo "${CRYPTEIA_VERSION}" | cut -d. -f1)
 
 docker login ghcr.io -u "metaskills" -p $DOCKER_LOGIN_PAT
 
+# Prevent BuildKit from wrapping single-platform builds in an OCI index
+# (attestation manifests), which breaks docker manifest create.
+export BUILDX_NO_DEFAULT_ATTESTATIONS=1
+
 ./amzn/setup
 BASE_NAME_AMD64="ghcr.io/rails-lambda/crypteia-extension-amzn-amd64"
 docker build \

--- a/package/deploy-image-debian
+++ b/package/deploy-image-debian
@@ -14,30 +14,28 @@ docker login ghcr.io -u "metaskills" -p $DOCKER_LOGIN_PAT
 BASE_NAME_AMD64="ghcr.io/rails-lambda/crypteia-extension-debian-amd64"
 docker build \
   --platform linux/amd64 \
-  --tag "${BASE_NAME_AMD64}:${CRYPTEIA_VERSION_MAJOR}" \
   --tag "${BASE_NAME_AMD64}:${CRYPTEIA_VERSION}" \
   --file package/Dockerfile .
-docker push "${BASE_NAME_AMD64}:${CRYPTEIA_VERSION_MAJOR}"
 docker push "${BASE_NAME_AMD64}:${CRYPTEIA_VERSION}"
 
 ./debian/setup-arm64
 BASE_NAME_ARM64="ghcr.io/rails-lambda/crypteia-extension-debian-arm64"
 docker build \
   --platform linux/arm64 \
-  --tag "${BASE_NAME_ARM64}:${CRYPTEIA_VERSION_MAJOR}" \
   --tag "${BASE_NAME_ARM64}:${CRYPTEIA_VERSION}" \
   --file package/Dockerfile .
-docker push "${BASE_NAME_ARM64}:${CRYPTEIA_VERSION_MAJOR}"
 docker push "${BASE_NAME_ARM64}:${CRYPTEIA_VERSION}"
 
-docker manifest create \
-  "ghcr.io/rails-lambda/crypteia-extension-debian:${CRYPTEIA_VERSION_MAJOR}" \
-  --amend "${BASE_NAME_AMD64}:${CRYPTEIA_VERSION_MAJOR}" \
-  --amend "${BASE_NAME_ARM64}:${CRYPTEIA_VERSION_MAJOR}"
-docker manifest push "ghcr.io/rails-lambda/crypteia-extension-debian:${CRYPTEIA_VERSION_MAJOR}"
-
+docker manifest rm "ghcr.io/rails-lambda/crypteia-extension-debian:${CRYPTEIA_VERSION}" 2>/dev/null || true
 docker manifest create \
   "ghcr.io/rails-lambda/crypteia-extension-debian:${CRYPTEIA_VERSION}" \
-  --amend "${BASE_NAME_AMD64}:${CRYPTEIA_VERSION}" \
-  --amend "${BASE_NAME_ARM64}:${CRYPTEIA_VERSION}"
+  "${BASE_NAME_AMD64}:${CRYPTEIA_VERSION}" \
+  "${BASE_NAME_ARM64}:${CRYPTEIA_VERSION}"
 docker manifest push "ghcr.io/rails-lambda/crypteia-extension-debian:${CRYPTEIA_VERSION}"
+
+docker manifest rm "ghcr.io/rails-lambda/crypteia-extension-debian:${CRYPTEIA_VERSION_MAJOR}" 2>/dev/null || true
+docker manifest create \
+  "ghcr.io/rails-lambda/crypteia-extension-debian:${CRYPTEIA_VERSION_MAJOR}" \
+  "${BASE_NAME_AMD64}:${CRYPTEIA_VERSION}" \
+  "${BASE_NAME_ARM64}:${CRYPTEIA_VERSION}"
+docker manifest push "ghcr.io/rails-lambda/crypteia-extension-debian:${CRYPTEIA_VERSION_MAJOR}"

--- a/package/deploy-image-debian
+++ b/package/deploy-image-debian
@@ -10,6 +10,10 @@ CRYPTEIA_VERSION_MAJOR=$(echo "${CRYPTEIA_VERSION}" | cut -d. -f1)
 
 docker login ghcr.io -u "metaskills" -p $DOCKER_LOGIN_PAT
 
+# Prevent BuildKit from wrapping single-platform builds in an OCI index
+# (attestation manifests), which breaks docker manifest create.
+export BUILDX_NO_DEFAULT_ATTESTATIONS=1
+
 ./bin/setup
 BASE_NAME_AMD64="ghcr.io/rails-lambda/crypteia-extension-debian-amd64"
 docker build \


### PR DESCRIPTION
## Summary

- GHCR refuses to overwrite a manifest-list tag with a single-arch image push, so `crypteia-extension-amzn-amd64:2` and `crypteia-extension-debian-amd64:2` stayed as manifest lists from a prior release, causing `docker manifest create` to fail with "is a manifest list"
- Remove the major-version tag (`:2`) from arch-specific image builds/pushes — those repos now only receive the exact version tag (`:2.2.1`)
- Both combined manifest lists (`:2.2.1` and `:2`) reference the exact-version arch images, which are always fresh tags
- Add `docker manifest rm … || true` before each `docker manifest create` to clear stale local manifest cache entries
- Fix deprecated `LABEL key value` → `LABEL key=value` syntax in `package/Dockerfile` (removes two build warnings)

## Test plan

- [ ] Trigger release workflow from this branch with a test version
- [ ] Confirm `debian` and `amzn` jobs pass without "is a manifest list" error
- [ ] Confirm multi-arch manifest tags `:VERSION` and `:MAJOR` are created correctly in GHCR